### PR TITLE
Allow declaring queues without binding.

### DIFF
--- a/test/conduit_amqp_test.exs
+++ b/test/conduit_amqp_test.exs
@@ -10,7 +10,12 @@ defmodule ConduitAmqpTest do
     end
   end
 
-  @topology [{:queue, "queue.test", from: ["#.test"], exchange: "exchange.test"}, {:exchange, "exchange.test", []}]
+  @topology [
+    {:exchange, "exchange.test", []},
+    {:queue, "queue.routing_key.test", from: ["#.test"], exchange: "exchange.test"},
+    {:queue, "queue.no_key.test", exchange: "exchange.test"},
+    {:queue, "queue.no_bind.test", []}
+  ]
   @subscribers %{queue_test: [from: "queue.test"]}
   setup_all do
     opts = Application.get_env(:conduit, ConduitAMQPTest)
@@ -35,8 +40,10 @@ defmodule ConduitAmqpTest do
 
   test "it configures the topology" do
     with_chan fn chan ->
-      assert {:ok, %{queue: "queue.test"}} = Queue.declare(chan, "queue.test", passive: true)
       assert :ok = Exchange.topic(chan, "exchange.test", passive: true)
+      assert {:ok, %{queue: "queue.routing_key.test"}} = Queue.declare(chan, "queue.routing_key.test", passive: true)
+      assert {:ok, %{queue: "queue.no_key.test"}} = Queue.declare(chan, "queue.no_key.test", passive: true)
+      assert {:ok, %{queue: "queue.no_bind.test"}} = Queue.declare(chan, "queue.no_bind.test", passive: true)
     end
   end
 


### PR DESCRIPTION
Sorry to bring this back, but my previous PR removed some functionality.

Before my PR (#2), you could declare a queue without specifying any bindings for it by not providing the `:from` option.  But now it forces you to have at least one binding (either with routing key, or without directly to exchange).

This PR re-introduces the ability to declare a queue without any bindings.  This is useful for the case where you're using dead-letter queues in rabbitmq and using the default exchange behavior of routing all messages to the appropriate queue by using the queue name as the routing key.

e.g.:

```elixir
defmodule MyBroker do
  use Conduit.Broker, otp_app: :my_app

  configure do
    exchange "my.exchange", type: :fanout, durable: true

    queue "my_app.my_queue", exchange: "my.exchange", durable: true
    # declare the dead-letter queue with no bindings
    queue "my_app.my_queue.error", durable: true
  end

  pipeline :error_handling do
    plug Conduit.Plug.DeadLetter, broker: MyBroker, publish_to: :error
  end

  incoming API do
    pipe_through [:error_handling]

    subscribe :my_queue, MySubscriber, from: "my_app.my_queue"
  end

  pipeline :error_destination do
    plug :put_destination, &(&1.source <> ".error")
  end

  outgoing do
    pipe_through [:error_destination]

    # publishing to the "" exchange in rabbitmq will route to the queue with the same name as the routing key
    publish(:error, exchange: "")
  end
end

```