### PR TITLE
fix publish/4 return

### DIFF
--- a/lib/conduit_amqp.ex
+++ b/lib/conduit_amqp.ex
@@ -70,7 +70,9 @@ defmodule ConduitAMQP do
     props = ConduitAMQP.Props.get(message)
 
     with_chan(broker, fn chan ->
-      Basic.publish(chan, exchange, message.destination, message.body, props)
+      with :ok <- Basic.publish(chan, exchange, message.destination, message.body, props) do
+        {:ok, message}
+      end
     end)
   end
 


### PR DESCRIPTION
Hey, first of all, thanks for this framework :)

My colleagues and I found that `publish/4` isn't returning the spec properly, only on TestAdapter because of [this commit](https://github.com/conduitframework/conduit/commit/adb2df1636077456d1be884a7c2941c8c0f08b3e#diff-edb64ddcb4ec9dc6b557d0e5bb2389a9).
Since [AMQP publish/5](https://hexdocs.pm/amqp/AMQP.Basic.html#publish/5) returns `:ok`, we need to change its return to conform with Conduit.Adapter spec `{:ok, Conduit.Message.t()}`. The error spec seems to be respected with AMQP.Basic error return.