### PR TITLE
Clarified docs & increased timeout for Dialyzer 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,10 @@ jobs:
       - run: mix compile
       - run: MIX_ENV=test mix compile
       - run: MIX_ENV=prod mix compile
-      - run: mix dialyzer --plt --no-compile
+      - run:
+          name: Dialyzer
+          command: mix dialyzer --plt --no-compile
+          no_output_timeout: 30m
       - save_cache:
           key: v6-build-{{checksum "mix.lock.frozen"}}
           paths:

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ options specified. You can override these options, by passing different options 
 ``` elixir
 defmodule MyApp.Broker do
   outgoing do
-    publish :something,
+    publish :destination_route,
       to: "my.routing_key",
       exchange: "amq.topic"
-    publish :something_else,
+    publish :other_destination_route,
       to: "my.other.routing_key",
       exchange: "amq.topic"
   end
@@ -149,12 +149,20 @@ end
 
 ### Options
 
-* `:to` - The routing key for the message. If the message already has it's destination set, this option will be ignored.
+* `:to` - The routing key for the message. If the message already has its destination set, this option will be ignored.
 * `:exchange` - The exchange to publish to. This option is required.
 - `:publisher_confirms` - This configures [publisher confirms](https://www.rabbitmq.com/confirms.html#publisher-confirms). Should be one of `:no_confirmation` (the default), `:wait` (if it should just return an `:timeout` atom on failure) or `:die` (raises an exception on timeout).
 - `:publisher_confirms_timeout` - The timeout in milliseconds for the server acknowledgement. Should be `:infinity` for no timeout (the default) or an integer number of milliseconds.
 
 See [basic.publish](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish) for more details.
+
+### Example usage
+
+```elixir
+%Message{}
+|> put_body(%{"my" => "message"})
+|> Broker.publish(:destination_route)
+```
 
 ## Architecture
 

--- a/lib/conduit_amqp.ex
+++ b/lib/conduit_amqp.ex
@@ -2,11 +2,24 @@ defmodule ConduitAMQP do
   @moduledoc """
   AMQP adapter for Conduit.
 
-    * `url` - Full connection url. Can be used instead of the individual connection options. Default is `amqp://guest:guest@localhost:5672/`.
+    _Either_ a full `url` should be provided
+
+    * `url` - Full connection url. Can be used instead of the individual
+    connection options (defaults to `amqp://guest:guest@localhost:5672/`);
+
+    _or_ these options:
+
     * `host` - Hostname of the broker (defaults to \"localhost\");
     * `port` - Port the broker is listening on (defaults to `5672`);
     * `username` - Username to connect to the broker as (defaults to \"guest\");
     * `password` - Password to connect to the broker with (defaults to \"guest\");
+
+    In other words, setting `url` to, say, `amqp://localhost:5672` as well as
+    `username` and `password` will make the latter two options be ignored -
+    a default `username` and `password` will be used instead.
+
+    Other options:
+
     * `virtual_host` - Name of a virtual host in the broker (defaults to \"/\");
     * `heartbeat` - Hearbeat interval in seconds (defaults to `0` - turned off);
     * `connection_timeout` - Connection timeout in milliseconds (defaults to `infinity`);


### PR DESCRIPTION
PS. Although I now wonder whether it'd be better to do away with `:url` option completely, [as Broadway seems to](https://github.com/dashbitco/broadway_rabbitmq/blob/054b2b9dbdf78f98ec9f33fc0a4a701999377953/lib/broadway_rabbitmq/amqp_client.ex#L15-L29), and merely do 
```elixir
case AMQP.Connection.open(state.opts) do
```
[in conn.ex](https://github.com/b1az/conduit_amqp/blob/5f1230b723d7b82ab4eac4b0e3dbdf456a277496/lib/conduit_amqp/conn.ex/#L30).

The reason being that `:heartbeat`, and other options, are also 'silently' ignored whenever `:url` is set.